### PR TITLE
Updates to make the axon db client compile and run with axonframework 4

### DIFF
--- a/axondb-client-java/pom.xml
+++ b/axondb-client-java/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.axoniq</groupId>
         <artifactId>axoniq-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3.5.axon4</version>
     </parent>
 
     <artifactId>axondb-client</artifactId>
@@ -66,7 +66,7 @@
         <!-- axon -->
         <dependency>
             <groupId>org.axonframework</groupId>
-            <artifactId>axon-core</artifactId>
+            <artifactId>axon-eventsourcing</artifactId>
             <version>${axon.version}</version>
             <optional>true</optional>
         </dependency>

--- a/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/AxonDBEventStore.java
+++ b/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/AxonDBEventStore.java
@@ -29,25 +29,23 @@ import io.axoniq.axondb.grpc.QueryEventsResponse;
 import io.axoniq.axondb.grpc.ReadHighestSequenceNrResponse;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.common.Assert;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventsourcing.DomainEventMessage;
-import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.AbstractEventStore;
-import org.axonframework.eventsourcing.eventstore.DomainEventData;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
-import org.axonframework.eventsourcing.eventstore.EventUtils;
-import org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken;
-import org.axonframework.eventsourcing.eventstore.TrackedEventData;
-import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
-import org.axonframework.eventsourcing.eventstore.TrackingToken;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-import org.axonframework.serialization.MessageSerializer;
+import org.axonframework.serialization.LazyDeserializingObject;
+import org.axonframework.serialization.SerializedMessage;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.serialization.upcasting.event.InitialEventRepresentation;
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
+import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,8 +53,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
@@ -92,19 +93,32 @@ public class AxonDBEventStore extends AbstractEventStore {
      * @param upcasterChain The upcaster to modify received Event representations with
      */
     public AxonDBEventStore(AxonDBConfiguration configuration, Serializer serializer, EventUpcaster upcasterChain) {
-        super(new AxonIQEventStorageEngine(serializer, upcasterChain, configuration, new AxonDBClient(configuration)));
+        super(builder()
+            .eventSerializer(serializer)
+            .snapshotSerializer(serializer)
+            .upcasterChain(upcasterChain)
+            .configuration(configuration)
+            .eventStoreClient(new AxonDBClient(configuration))
+            .buildStorageEngineIfMissing());
     }
 
     /**
      * Initialize the Event Store using given {@code configuration}, {@code serializer} and {@code upcasterChain}
      * Allows for different serializers for snapshots and events (requires AxonFramework version 3.3 or higer)
-     * @param configuration The configuration describing the servers to connect with and how to manage flow control
-     * @param snapshotSerializer    The serializer to serialize Snapshot payloads with
-     * @param eventSerializer   The serializer to serialize Event payloads with
-     * @param upcasterChain The upcaster to modify received Event representations with
+     *
+     * @param configuration      The configuration describing the servers to connect with and how to manage flow control
+     * @param snapshotSerializer The serializer to serialize Snapshot payloads with
+     * @param eventSerializer    The serializer to serialize Event payloads with
+     * @param upcasterChain      The upcaster to modify received Event representations with
      */
     public AxonDBEventStore(AxonDBConfiguration configuration, Serializer snapshotSerializer, Serializer eventSerializer, EventUpcaster upcasterChain) {
-        super(new AxonIQEventStorageEngine(snapshotSerializer, eventSerializer, upcasterChain, configuration, new AxonDBClient(configuration)));
+        super(builder()
+            .eventSerializer(eventSerializer)
+            .snapshotSerializer(snapshotSerializer)
+            .upcasterChain(upcasterChain)
+            .configuration(configuration)
+            .eventStoreClient(new AxonDBClient(configuration))
+            .buildStorageEngineIfMissing());
     }
 
     @Override
@@ -115,6 +129,77 @@ public class AxonDBEventStore extends AbstractEventStore {
 
     public QueryResultStream query(String query, boolean liveUpdates) {
         return storageEngine().query(query, liveUpdates);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static class Builder extends AbstractEventStore.Builder {
+
+        private AxonDBConfiguration configuration;
+        private AxonDBClient eventStoreClient;
+        private Serializer snapshotSerializer = XStreamSerializer.builder().build();
+        private Serializer eventSerializer = XStreamSerializer.builder().build();
+        private EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
+
+        @Override
+        public Builder storageEngine(EventStorageEngine storageEngine) {
+            super.storageEngine(storageEngine);
+            return this;
+        }
+
+        public Builder configuration(AxonDBConfiguration configuration) {
+            assertNonNull(configuration, "The configuration may not be null");
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder eventStoreClient(AxonDBClient eventStoreClient) {
+            assertNonNull(eventStoreClient, "The eventStoreClient may not be null");
+            this.eventStoreClient = eventStoreClient;
+            return this;
+        }
+
+        public Builder snapshotSerializer(Serializer snapshotSerializer) {
+            assertNonNull(snapshotSerializer, "The Snapshot Serializer may not be null");
+            this.snapshotSerializer = snapshotSerializer;
+            return this;
+        }
+
+        public Builder eventSerializer(Serializer eventSerializer) {
+            assertNonNull(eventSerializer, "The Event Serializer may not be null");
+            this.eventSerializer = eventSerializer;
+            return this;
+        }
+
+        public Builder upcasterChain(EventUpcaster upcasterChain) {
+            assertNonNull(upcasterChain, "EventUpcaster may not be null");
+            this.upcasterChain = upcasterChain;
+            return this;
+        }
+
+        public Builder buildStorageEngineIfMissing() {
+            if (storageEngine == null) {
+                buildStorageEngine();
+            }
+            return this;
+        }
+
+        private void buildStorageEngine() {
+            super.storageEngine(new AxonIQEventStorageEngine(snapshotSerializer, eventSerializer, upcasterChain, configuration, eventStoreClient));
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        @Override
+        protected void validate() throws AxonConfigurationException {
+            super.validate();
+        }
     }
 
     @Override
@@ -136,7 +221,10 @@ public class AxonDBEventStore extends AbstractEventStore {
                                          EventUpcaster upcasterChain,
                                          AxonDBConfiguration configuration,
                                          AxonDBClient eventStoreClient) {
-            super(serializer, upcasterChain, null);
+            super(builder()
+                .eventSerializer(serializer)
+                .snapshotSerializer(serializer)
+                .upcasterChain(upcasterChain));
             this.upcasterChain = getOrDefault(upcasterChain, NoOpEventUpcaster.INSTANCE);
             this.configuration = configuration;
             this.eventStoreClient = eventStoreClient;
@@ -148,11 +236,18 @@ public class AxonDBEventStore extends AbstractEventStore {
                                          EventUpcaster upcasterChain,
                                          AxonDBConfiguration configuration,
                                          AxonDBClient eventStoreClient) {
-            super(serializer, upcasterChain, null, eventSerializer, null);
+            super(builder()
+                .eventSerializer(eventSerializer)
+                .snapshotSerializer(serializer)
+                .upcasterChain(upcasterChain));
             this.upcasterChain = getOrDefault(upcasterChain, NoOpEventUpcaster.INSTANCE);
             this.configuration = configuration;
             this.eventStoreClient = eventStoreClient;
             this.converter = new GrpcMetaDataConverter(serializer);
+        }
+
+        private static Builder builder() {
+            return new Builder();
         }
 
         @Override
@@ -180,16 +275,16 @@ public class AxonDBEventStore extends AbstractEventStore {
             Event.Builder builder = Event.newBuilder();
             if (eventMessage instanceof GenericDomainEventMessage) {
                 builder.setAggregateIdentifier(((GenericDomainEventMessage) eventMessage).getAggregateIdentifier())
-                       .setAggregateSequenceNumber(((GenericDomainEventMessage) eventMessage).getSequenceNumber())
-                       .setAggregateType(((GenericDomainEventMessage) eventMessage).getType());
+                    .setAggregateSequenceNumber(((GenericDomainEventMessage) eventMessage).getSequenceNumber())
+                    .setAggregateType(((GenericDomainEventMessage) eventMessage).getType());
             }
-            SerializedObject<byte[]> serializedPayload = MessageSerializer.serializePayload(eventMessage, serializer, byte[].class);
+            SerializedObject<byte[]> serializedPayload = eventMessage.serializePayload(serializer, byte[].class);
             builder.setMessageIdentifier(eventMessage.getIdentifier())
-                   .setPayload(io.axoniq.platform.SerializedObject.newBuilder()
-                                                                    .setType(serializedPayload.getType().getName())
-                                                                    .setRevision(getOrDefault(serializedPayload.getType().getRevision(), ""))
-                                                                    .setData(ByteString.copyFrom(serializedPayload.getData())))
-                   .setTimestamp(eventMessage.getTimestamp().toEpochMilli());
+                .setPayload(io.axoniq.platform.SerializedObject.newBuilder()
+                    .setType(serializedPayload.getType().getName())
+                    .setRevision(getOrDefault(serializedPayload.getType().getRevision(), ""))
+                    .setData(ByteString.copyFrom(serializedPayload.getData())))
+                .setTimestamp(eventMessage.getTimestamp().toEpochMilli());
             eventMessage.getMetaData().forEach((k, v) -> builder.putMetaData(k, converter.convertToMetaDataValue(v)));
             return builder.build();
         }
@@ -219,7 +314,7 @@ public class AxonDBEventStore extends AbstractEventStore {
         protected Stream<? extends DomainEventData<?>> readEventData(String aggregateIdentifier, long firstSequenceNumber) {
             logger.debug("Reading events for aggregate id {}", aggregateIdentifier);
             GetAggregateEventsRequest.Builder request = GetAggregateEventsRequest.newBuilder()
-                                                                                 .setAggregateId(aggregateIdentifier);
+                .setAggregateId(aggregateIdentifier);
             if (firstSequenceNumber > 0) {
                 request.setInitialSequence(firstSequenceNumber);
             } else if (firstSequenceNumber == ALLOW_SNAPSHOTS_MAGIC_VALUE) {
@@ -234,7 +329,7 @@ public class AxonDBEventStore extends AbstractEventStore {
 
         public TrackingEventStream openStream(TrackingToken trackingToken) {
             Assert.isTrue(trackingToken == null || trackingToken instanceof GlobalSequenceTrackingToken,
-                          () -> "Invalid tracking token type. Must be GlobalSequenceTrackingToken.");
+                () -> "Invalid tracking token type. Must be GlobalSequenceTrackingToken.");
             long nextToken = trackingToken == null ? 0 : ((GlobalSequenceTrackingToken) trackingToken).getGlobalIndex() + 1;
             EventBuffer consumer = new EventBuffer(upcasterChain, getEventSerializer());
 
@@ -258,12 +353,12 @@ public class AxonDBEventStore extends AbstractEventStore {
                 }
             });
             FlowControllingStreamObserver<GetEventsRequest> observer = new FlowControllingStreamObserver<>(
-                    requestStream, configuration, t-> GetEventsRequest.newBuilder().setNumberOfPermits(t).build(), t-> false);
+                requestStream, configuration, t -> GetEventsRequest.newBuilder().setNumberOfPermits(t).build(), t -> false);
 
             GetEventsRequest request = GetEventsRequest.newBuilder()
-                    .setTrackingToken(nextToken)
-                    .setNumberOfPermits(configuration.getInitialNrOfPermits())
-                    .build();
+                .setTrackingToken(nextToken)
+                .setNumberOfPermits(configuration.getInitialNrOfPermits())
+                .build();
             observer.onNext(request);
 
             consumer.registerCloseListener((eventConsumer) -> observer.onCompleted());
@@ -294,13 +389,13 @@ public class AxonDBEventStore extends AbstractEventStore {
                 }
             });
             FlowControllingStreamObserver<QueryEventsRequest> observer = new FlowControllingStreamObserver<>(
-                    requestStream, configuration, t-> QueryEventsRequest.newBuilder().setNumberOfPermits(t).build(), t-> false);
+                requestStream, configuration, t -> QueryEventsRequest.newBuilder().setNumberOfPermits(t).build(), t -> false);
 
             observer.onNext(QueryEventsRequest.newBuilder()
-                    .setQuery(query)
-                    .setNumberOfPermits(configuration.getInitialNrOfPermits())
-                    .setLiveEvents(liveUpdates)
-                    .build());
+                .setQuery(query)
+                .setNumberOfPermits(configuration.getInitialNrOfPermits())
+                .setLiveEvents(liveUpdates)
+                .build());
 
             consumer.registerCloseListener((eventConsumer) -> observer.onCompleted());
             consumer.registerConsumeListener(observer::markConsumed);
@@ -314,19 +409,51 @@ public class AxonDBEventStore extends AbstractEventStore {
             return DomainEventStream.of(input.map(this::upcastAndDeserializeDomainEvent).filter(Objects::nonNull));
         }
 
-        private  DomainEventMessage<?> upcastAndDeserializeDomainEvent(DomainEventData<?> domainEventData) {
-            DomainEventStream upcastedStream = EventUtils.upcastAndDeserializeDomainEvents(Stream.of(domainEventData),
-                                                                                                new GrpcMetaDataAwareSerializer(
-                                                                                                        isSnapshot(
-                                                                                                                domainEventData) ? getSerializer() : getEventSerializer()),
-                                                                                                upcasterChain,
-                                                                                                false);
+        private DomainEventMessage<?> upcastAndDeserializeDomainEvent(DomainEventData<?> domainEventData) {
+            DomainEventStream upcastedStream = upcastAndDeserializeDomainEvents(
+                Stream.of(domainEventData),
+                new GrpcMetaDataAwareSerializer(isSnapshot(domainEventData) ? getSnapshotSerializer() : getEventSerializer()),
+                upcasterChain);
             return upcastedStream.hasNext() ? upcastedStream.next() : null;
         }
 
+        private DomainEventStream upcastAndDeserializeDomainEvents(
+            Stream<? extends DomainEventData<?>> eventEntryStream, Serializer serializer, EventUpcaster upcasterChain) {
+            AtomicReference<Long> currentSequenceNumber = new AtomicReference<>();
+            Stream<IntermediateEventRepresentation> upcastResult =
+                upcastAndDeserialize(eventEntryStream, upcasterChain, entry -> {
+                    InitialEventRepresentation result = new InitialEventRepresentation(entry, serializer);
+                    currentSequenceNumber.set(result.getSequenceNumber().get());
+                    return result;
+                });
+            Stream<? extends DomainEventMessage<?>> stream = upcastResult.map(ir -> {
+                SerializedMessage<?> serializedMessage = new SerializedMessage<>(ir.getMessageIdentifier(),
+                    new LazyDeserializingObject<>(
+                        ir::getData,
+                        ir.getType(), serializer),
+                    ir.getMetaData());
+                if (ir.getTrackingToken().isPresent()) {
+                    return new GenericTrackedDomainEventMessage<>(ir.getTrackingToken().get(), ir.getAggregateType().get(),
+                        ir.getAggregateIdentifier().get(),
+                        ir.getSequenceNumber().get(), serializedMessage,
+                        ir::getTimestamp);
+                } else {
+                    return new GenericDomainEventMessage<>(ir.getAggregateType().get(), ir.getAggregateIdentifier().get(),
+                        ir.getSequenceNumber().get(), serializedMessage,
+                        ir::getTimestamp);
+                }
+            });
+            return DomainEventStream.of(stream, currentSequenceNumber::get);
+        }
+
+        private Stream<IntermediateEventRepresentation> upcastAndDeserialize(Stream<? extends EventData<?>> eventEntryStream, EventUpcaster upcasterChain,
+                                                                             Function<EventData<?>, IntermediateEventRepresentation> entryConverter) {
+            return upcasterChain.upcast(eventEntryStream.map(entryConverter));
+        }
+
         private boolean isSnapshot(DomainEventData<?> domainEventData) {
-            if( domainEventData instanceof GrpcBackedDomainEventData) {
-                GrpcBackedDomainEventData grpcBackedDomainEventData = (GrpcBackedDomainEventData)domainEventData;
+            if (domainEventData instanceof GrpcBackedDomainEventData) {
+                GrpcBackedDomainEventData grpcBackedDomainEventData = (GrpcBackedDomainEventData) domainEventData;
                 return grpcBackedDomainEventData.isSnapshot();
             }
             return false;
@@ -336,7 +463,7 @@ public class AxonDBEventStore extends AbstractEventStore {
         public Optional<Long> lastSequenceNumberFor(String aggregateIdentifier) {
             try {
                 ReadHighestSequenceNrResponse lastSequenceNr = eventStoreClient
-                        .lastSequenceNumberFor(aggregateIdentifier).get();
+                    .lastSequenceNumberFor(aggregateIdentifier).get();
                 return lastSequenceNr.getToSequenceNr() < 0 ? Optional.empty() : Optional.of(lastSequenceNr.getToSequenceNr());
             } catch (Throwable e) {
                 throw AxonErrorMapping.convert(e);
@@ -347,8 +474,10 @@ public class AxonDBEventStore extends AbstractEventStore {
         public TrackingToken createTailToken() {
             try {
                 io.axoniq.axondb.grpc.TrackingToken token = eventStoreClient.getFirstToken().get();
-                if( token.getToken() < 0) return null;
-                return new GlobalSequenceTrackingToken(token.getToken()-1);
+                if (token.getToken() < 0) {
+                    return null;
+                }
+                return new GlobalSequenceTrackingToken(token.getToken() - 1);
             } catch (Throwable e) {
                 throw AxonErrorMapping.convert(e);
             }
@@ -368,8 +497,10 @@ public class AxonDBEventStore extends AbstractEventStore {
         public TrackingToken createTokenAt(Instant instant) {
             try {
                 io.axoniq.axondb.grpc.TrackingToken token = eventStoreClient.getTokenAt(instant).get();
-                if( token.getToken() < 0) return null;
-                return new GlobalSequenceTrackingToken(token.getToken()-1);
+                if (token.getToken() < 0) {
+                    return null;
+                }
+                return new GlobalSequenceTrackingToken(token.getToken() - 1);
             } catch (Throwable e) {
                 throw AxonErrorMapping.convert(e);
             }
@@ -381,9 +512,13 @@ public class AxonDBEventStore extends AbstractEventStore {
         }
 
         @Override
-        protected Optional<? extends DomainEventData<?>> readSnapshotData(String aggregateIdentifier) {
+        protected Stream<? extends DomainEventData<?>> readSnapshotData(String aggregateIdentifier) {
             // snapshots are automatically fetched server-side, which is faster
-            return Optional.empty();
+            return Stream.empty();
+        }
+
+        private static class Builder extends AbstractEventStorageEngine.Builder {
+
         }
 
     }

--- a/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/AxonErrorMapping.java
+++ b/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/AxonErrorMapping.java
@@ -16,10 +16,10 @@
 package io.axoniq.axondb.client.axon;
 
 import io.axoniq.axondb.client.util.EventStoreClientException;
-import org.axonframework.commandhandling.model.AggregateRolledBackException;
-import org.axonframework.commandhandling.model.ConcurrencyException;
 import org.axonframework.common.AxonException;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.modelling.command.AggregateRolledBackException;
+import org.axonframework.modelling.command.ConcurrencyException;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;

--- a/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/EventBuffer.java
+++ b/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/EventBuffer.java
@@ -16,9 +16,14 @@
 package io.axoniq.axondb.client.axon;
 
 import io.axoniq.axondb.grpc.EventWithToken;
+import org.axonframework.eventhandling.EventUtils;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackedDomainEventData;
+import org.axonframework.eventhandling.TrackedEventData;
 import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventsourcing.eventstore.*;
-import org.axonframework.serialization.*;
+import org.axonframework.eventhandling.TrackingEventStream;
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
 import org.slf4j.Logger;
@@ -71,8 +76,7 @@ public class EventBuffer implements TrackingEventStream {
         this.events = new LinkedBlockingQueue<>();
         eventStream = EventUtils.upcastAndDeserializeTrackedEvents(StreamSupport.stream(new SimpleSpliterator<>(this::poll), false),
                                                                    new GrpcMetaDataAwareSerializer(serializer),
-                                                                   getOrDefault(upcasterChain, NoOpEventUpcaster.INSTANCE),
-                                                                   true)
+                                                                   getOrDefault(upcasterChain, NoOpEventUpcaster.INSTANCE))
                                 .iterator();
     }
 

--- a/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/GrpcBackedDomainEventData.java
+++ b/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/GrpcBackedDomainEventData.java
@@ -16,7 +16,7 @@
 package io.axoniq.axondb.client.axon;
 
 import io.axoniq.axondb.Event;
-import org.axonframework.eventsourcing.eventstore.DomainEventData;
+import org.axonframework.eventhandling.DomainEventData;
 import org.axonframework.serialization.SerializedMetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SimpleSerializedObject;
@@ -86,7 +86,7 @@ public class GrpcBackedDomainEventData implements DomainEventData<byte[]> {
     @Override
     public SerializedObject<byte[]> getPayload() {
         String revision = event.getPayload().getRevision();
-        return new SimpleSerializedObject<>(event.getPayload().getData().toByteArray(),
+        return new SimpleSerializedObject<byte[]>(event.getPayload().getData().toByteArray(),
                                             byte[].class, event.getPayload().getType(),
                                             "".equals(revision) ? null : revision);
     }

--- a/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/GrpcMetaDataAwareSerializer.java
+++ b/axondb-client-java/src/main/java/io/axoniq/axondb/client/axon/GrpcMetaDataAwareSerializer.java
@@ -19,7 +19,6 @@ import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.UnknownSerializedTypeException;
 
 import java.util.Map;
 
@@ -59,7 +58,7 @@ public class GrpcMetaDataAwareSerializer implements Serializer {
     }
 
     @Override
-    public Class classForType(SerializedType type) throws UnknownSerializedTypeException {
+    public Class classForType(SerializedType type) {
         return delegate.classForType(type);
     }
 

--- a/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/AxonDBEventStoreTest.java
+++ b/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/AxonDBEventStoreTest.java
@@ -18,7 +18,7 @@ package io.axoniq.axondb.client.axon;
 import io.axoniq.axondb.client.AxonDBConfiguration;
 import io.axoniq.axondb.client.StubServer;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
+import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
@@ -46,7 +46,7 @@ public class AxonDBEventStoreTest {
         AxonDBConfiguration config = AxonDBConfiguration.newBuilder("localhost:6123")
                                                                 .flowControl(2, 1, 1)
                                                                 .build();
-        testSubject = new AxonDBEventStore(config, new XStreamSerializer());
+        testSubject = new AxonDBEventStore(config, XStreamSerializer.builder().build());
     }
 
     @After

--- a/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/AxonErrorMappingTest.java
+++ b/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/AxonErrorMappingTest.java
@@ -16,8 +16,8 @@
 package io.axoniq.axondb.client.axon;
 
 import io.axoniq.axondb.client.util.EventStoreClientException;
-import org.axonframework.commandhandling.model.ConcurrencyException;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.modelling.command.ConcurrencyException;
 import org.junit.Test;
 
 

--- a/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/EventBufferTest.java
+++ b/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/EventBufferTest.java
@@ -19,9 +19,9 @@ import com.google.protobuf.ByteString;
 import io.axoniq.axondb.Event;
 import io.axoniq.axondb.grpc.EventWithToken;
 import io.axoniq.platform.SerializedObject;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventsourcing.DomainEventMessage;
-import org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.xml.XStreamSerializer;
@@ -34,10 +34,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class EventBufferTest {
     private EventUpcaster stubUpcaster;
@@ -50,7 +54,7 @@ public class EventBufferTest {
     public void setUp() throws Exception {
         stubUpcaster = mock(EventUpcaster.class);
         when(stubUpcaster.upcast(any())).thenAnswer((Answer<Stream<IntermediateEventRepresentation>>) invocationOnMock -> (Stream<IntermediateEventRepresentation>) invocationOnMock.getArguments()[0]);
-        serializer = new XStreamSerializer();
+        serializer = XStreamSerializer.builder().build();
 
         serializedObject = serializer.serialize("some object", byte[].class);
     }

--- a/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/GrpcQueryTest.java
+++ b/axondb-client-java/src/test/java/io/axoniq/axondb/client/axon/GrpcQueryTest.java
@@ -44,7 +44,7 @@ public class GrpcQueryTest {
         AxonDBConfiguration axonDb = AxonDBConfiguration.newBuilder("localhost:6123")
                 .flowControl(10000, 9000, 1000)
                 .build();
-        axonDBEventStore = new AxonDBEventStore(axonDb, new JacksonSerializer());
+        axonDBEventStore = new AxonDBEventStore(axonDb, JacksonSerializer.builder().build());
 
     }
 

--- a/axondb-grpc-proto/pom.xml
+++ b/axondb-grpc-proto/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.axoniq</groupId>
         <artifactId>axoniq-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3.5.axon4</version>
     </parent>
 
     <build>

--- a/examples/axondb-client-example-nospring/pom.xml
+++ b/examples/axondb-client-example-nospring/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.axoniq</groupId>
         <artifactId>axoniq-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3.5.axon4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.axonframework</groupId>
-            <artifactId>axon-core</artifactId>
+            <artifactId>axon-eventsourcing</artifactId>
             <version>${axon.version}</version>
         </dependency>
         <dependency>

--- a/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/ClientNoSpring.java
+++ b/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/ClientNoSpring.java
@@ -17,9 +17,9 @@ package io.axoniq.axonclient;
 
 import io.axoniq.axondb.client.AxonDBConfiguration;
 import io.axoniq.axondb.client.axon.AxonDBEventStore;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventsourcing.GenericTrackedDomainEventMessage;
-import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
+import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 
@@ -41,7 +41,7 @@ public class ClientNoSpring {
                 .ssl("resources/axoniq-public.crt")
                 .build();
 
-        Serializer serializer = new JacksonSerializer();
+        Serializer serializer = JacksonSerializer.builder().build();
         AxonDBEventStore eventStore = new AxonDBEventStore(axonDBConfiguration, serializer);
         try {
             TrackingEventStream stream = eventStore.openStream(null);

--- a/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/ClientNoSpring2.java
+++ b/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/ClientNoSpring2.java
@@ -18,7 +18,7 @@ package io.axoniq.axonclient;
 import io.axoniq.axondb.client.AxonDBConfiguration;
 import io.axoniq.axondb.client.axon.AxonDBEventStore;
 import io.axoniq.axondb.performancetest.TestEvent;
-import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
@@ -49,7 +49,7 @@ public class ClientNoSpring2 {
                                                                                  .ssl("resources/axoniq-public.crt")
                                                                                  .build();
 
-        Serializer serializer = new JacksonSerializer();
+        Serializer serializer = JacksonSerializer.builder().build();
         AxonDBEventStore eventStore = new AxonDBEventStore(axonDBConfiguration, serializer);
 
         IntStream.range(0, NR_AGGREGATES).forEach(i -> {

--- a/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/MultipleSerializers.java
+++ b/examples/axondb-client-example-nospring/src/main/java/io/axoniq/axonclient/MultipleSerializers.java
@@ -19,7 +19,7 @@ import io.axoniq.axondb.client.AxonDBConfiguration;
 import io.axoniq.axondb.client.axon.AxonDBEventStore;
 import io.axoniq.axondb.performancetest.TestAggregate;
 import io.axoniq.axondb.performancetest.TestEvent;
-import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
@@ -42,8 +42,8 @@ public class MultipleSerializers {
         AxonDBConfiguration axonDBConfiguration = AxonDBConfiguration.newBuilder("localhost")
                                                                                  .build();
 
-        Serializer serializer = new XStreamSerializer();
-        Serializer eventSerializer = new JacksonSerializer();
+        Serializer serializer = XStreamSerializer.builder().build();
+        Serializer eventSerializer = JacksonSerializer.builder().build();
         AxonDBEventStore eventStore = new AxonDBEventStore(axonDBConfiguration, serializer, eventSerializer, NoOpEventUpcaster.INSTANCE);
         String aggregateId = UUID.randomUUID().toString();
 

--- a/examples/axondb-client-example/pom.xml
+++ b/examples/axondb-client-example/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.axoniq</groupId>
         <artifactId>axoniq-client-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3.5.axon4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/axondb-client-example/src/main/java/com/example/command/BankAccountAggregate.java
+++ b/examples/axondb-client-example/src/main/java/com/example/command/BankAccountAggregate.java
@@ -19,11 +19,12 @@ import com.example.events.BankAccountCreatedEvent;
 import com.example.events.MoneyDepositedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.commandhandling.model.AggregateIdentifier;
 import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.spring.stereotype.Aggregate;
 
-import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+
 
 /**
  * @author Zoltan Altfatter

--- a/examples/axondb-client-example/src/main/java/com/example/command/CreateBankAccountCommand.java
+++ b/examples/axondb-client-example/src/main/java/com/example/command/CreateBankAccountCommand.java
@@ -17,7 +17,7 @@ package com.example.command;
 
 import lombok.Builder;
 import lombok.Data;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
 import javax.validation.constraints.Min;
 

--- a/examples/axondb-client-example/src/main/java/com/example/command/DepositMoneyCommand.java
+++ b/examples/axondb-client-example/src/main/java/com/example/command/DepositMoneyCommand.java
@@ -17,7 +17,7 @@ package com.example.command;
 
 import lombok.Builder;
 import lombok.Data;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
 /**
  * @author Zoltan Altfatter

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.axoniq</groupId>
     <artifactId>axoniq-client-parent</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3.5.axon4</version>
 
     <packaging>pom</packaging>
 
@@ -52,7 +52,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <axon.version>3.3.1</axon.version>
+        <axon.version>4.0</axon.version>
         <swagger.version>2.7.0</swagger.version>
         <slf4j.version>1.7.25</slf4j.version>
         <jackson.version>2.9.0</jackson.version>


### PR DESCRIPTION
These were just quick changes, no javadocs were added or not all best practices were applied. The axon server connector project was also used as a reference to fix some things. Main concern was to keep it backwards compatible and still be able to use axonframework 4. If you have any questions or remarks, I'll try and follow them up.